### PR TITLE
Fix race condition with multiplex sandboxed workers

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/PlatformOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/PlatformOptions.java
@@ -20,7 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.analysis.config.CoreOptionConverters;
-import com.google.devtools.build.lib.analysis.config.CoreOptionConverters.EmptyToNullLabelConverter;
+import com.google.devtools.build.lib.analysis.config.CoreOptionConverters.LabelConverter;
 import com.google.devtools.build.lib.analysis.config.CoreOptionConverters.LabelListConverter;
 import com.google.devtools.build.lib.analysis.config.FragmentOptions;
 import com.google.devtools.build.lib.cmdline.Label;
@@ -46,6 +46,8 @@ public class PlatformOptions extends FragmentOptions {
   private static final ImmutableSet<String> DEFAULT_PLATFORM_NAMES =
       ImmutableSet.of("host", "host_platform", "target_platform", "default_host", "default_target");
 
+  public static final String DEFAULT_HOST_PLATFORM = "@bazel_tools//tools:host_platform";
+
   public static boolean platformIsDefault(Label platform) {
     return DEFAULT_PLATFORM_NAMES.contains(platform.getName());
   }
@@ -53,8 +55,8 @@ public class PlatformOptions extends FragmentOptions {
   @Option(
       name = "host_platform",
       oldName = "experimental_host_platform",
-      converter = EmptyToNullLabelConverter.class,
-      defaultValue = "@bazel_tools//tools:host_platform",
+      converter = HostPlatformConverter.class,
+      defaultValue = DEFAULT_HOST_PLATFORM,
       documentationCategory = OptionDocumentationCategory.TOOLCHAIN,
       effectTags = {
         OptionEffectTag.AFFECTS_OUTPUTS,
@@ -220,6 +222,21 @@ public class PlatformOptions extends FragmentOptions {
     } else {
       // Default to the host platform, whatever it is.
       return hostPlatform;
+    }
+  }
+
+  /**
+   * Converter for {@code --host_platform} that returns the default host platform if the flag is set
+   * to empty string.
+   */
+  private static final class HostPlatformConverter extends LabelConverter {
+    @Override
+    @Nullable
+    public Label convert(String input, Object conversionContext) throws OptionsParsingException {
+      if (input.isEmpty()) {
+        return super.convert(DEFAULT_HOST_PLATFORM, conversionContext);
+      }
+      return super.convert(input, conversionContext);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerFactory.java
@@ -95,7 +95,8 @@ public class WorkerFactory {
     if (key.isSandboxed()) {
       if (key.isMultiplex()) {
         WorkerMultiplexer workerMultiplexer = WorkerMultiplexerManager.getInstance(key, logFile);
-        Path workDir = getSandboxedWorkerPath(key);
+        int multiplexerId = workerMultiplexer.getMultiplexerId();
+        Path workDir = getMultiplexSandboxedWorkerPath(key, multiplexerId);
         worker =
             new SandboxedWorkerProxy(
                 key, workerId, logFile, workerMultiplexer, workDir, treeDeleter);
@@ -145,10 +146,11 @@ public class WorkerFactory {
         .getRelative(workspaceName);
   }
 
-  Path getSandboxedWorkerPath(WorkerKey key) {
+  Path getMultiplexSandboxedWorkerPath(WorkerKey key, int multiplexerId) {
     String workspaceName = key.getExecRoot().getBaseName();
     return workerBaseDir
-        .getRelative(key.getMnemonic() + "-" + key.getWorkerTypeName() + "-workdir")
+        .getRelative(
+              key.getMnemonic() + "-" + key.getWorkerTypeName() + "-" + multiplexerId + "-workdir")
         .getRelative(workspaceName);
   }
 

--- a/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
+++ b/src/main/java/com/google/devtools/build/lib/worker/WorkerMultiplexer.java
@@ -61,6 +61,14 @@ public class WorkerMultiplexer {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
   /**
+   * An ID for this multiplexer that can be used by sandboxed multiplex workers to generate their
+   * workdir. The workdir needs to be the same for all {@code SandboxedWorkerProxy} instances
+   * associated with a {@code WorkerMultiplexer}, but needs to be unique across multiplexers for the
+   * same mnemonic. This is analogous to the @{code workerId} created in {@code WorkerFactory}.
+   */
+  private final int multiplexerId;
+
+  /**
    * A queue of {@link WorkRequest} instances that need to be sent to the worker. {@link
    * WorkerProxy} instances add to this queue, while the requestSender subthread remove requests and
    * send them to the worker. This prevents dynamic execution interrupts from corrupting the {@code
@@ -125,10 +133,11 @@ public class WorkerMultiplexer {
    */
   private Thread shutdownHook;
 
-  WorkerMultiplexer(Path logFile, WorkerKey workerKey) {
+  WorkerMultiplexer(Path logFile, WorkerKey workerKey, int multiplexerId) {
     this.status = new WorkerProcessStatus();
     this.logFile = logFile;
     this.workerKey = workerKey;
+    this.multiplexerId = multiplexerId;
   }
 
   /** Sets or clears the reporter for outputting verbose info. */
@@ -484,5 +493,9 @@ public class WorkerMultiplexer {
       return -1;
     }
     return process.getProcessId();
+  }
+
+  public int getMultiplexerId() {
+    return this.multiplexerId;
   }
 }

--- a/src/test/java/com/google/devtools/build/lib/analysis/PlatformOptionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/PlatformOptionsTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.analysis.util.OptionsTestCase;
+import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.skyframe.config.PlatformMappingKey;
 import com.google.devtools.build.lib.vfs.PathFragment;
 import com.google.devtools.common.options.OptionsParsingException;
@@ -32,6 +33,7 @@ public final class PlatformOptionsTest extends OptionsTestCase<PlatformOptions> 
   private static final String EXTRA_TOOLCHAINS_PREFIX = "--extra_toolchains=";
   private static final String PLATFORMS_PREFIX = "--platforms=";
   private static final String PLATFORM_MAPPINGS_PREFIX = "--platform_mappings=";
+  private static final String HOST_PLATFORM_PREFIX = "--host_platform=";
 
   @Override
   protected Class<PlatformOptions> getOptionsClass() {
@@ -113,5 +115,12 @@ public final class PlatformOptionsTest extends OptionsTestCase<PlatformOptions> 
     assertThrows(
         OptionsParsingException.class,
         () -> createWithPrefix(PLATFORM_MAPPINGS_PREFIX, "/a/b/platform_mappings"));
+  }
+
+  @Test
+  public void hostPlatformEmpty_default() throws Exception {
+    PlatformOptions options = createWithPrefix(HOST_PLATFORM_PREFIX, "");
+    assertThat(options.hostPlatform)
+        .isEqualTo(Label.parseCanonicalUnchecked(PlatformOptions.DEFAULT_HOST_PLATFORM));
   }
 }


### PR DESCRIPTION
Prior to this change, multiplex sandboxed workers shared a working directory per mnemonic. This caused a race condition when a new multiplex sandboxed worker with the same mnemonic was launched. When launching it cleaned the working directory, which could cause problems for any actions executing in that directory.

This change makes it so each multiplex sandbox worker process has a unique working directory. It does so while ensuring each SandboxedWorkerProxy and its sandbox is still associated with the correct multiplexer working directory.