### PR TITLE
Bfreestone adds execlog differ

### DIFF
--- a/src/tools/execlog/BUILD
+++ b/src/tools/execlog/BUILD
@@ -27,3 +27,10 @@ java_binary(
     visibility = ["//visibility:public"],
     runtime_deps = ["//src/tools/execlog/src/main/java/com/google/devtools/build/execlog:converter"],
 )
+
+java_binary(
+    name = "differ",
+    main_class = "com.google.devtools.build.execlog.ExecLogDiffer",
+    visibility = ["//visibility:public"],
+    runtime_deps = ["//src/tools/execlog/src/main/java/com/google/devtools/build/execlog:differ"],
+)

--- a/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/BUILD
+++ b/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/BUILD
@@ -42,3 +42,14 @@ java_library(
         "//third_party:guava",
     ],
 )
+
+java_library(
+    name = "differ",
+    srcs = [
+        "DifferOptions.java",
+        "ExecLogDiffer.java",
+    ],
+    deps = [
+        "//src/main/java/com/google/devtools/common/options",
+    ]
+)

--- a/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/BUILD
+++ b/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/BUILD
@@ -50,6 +50,10 @@ java_library(
         "ExecLogDiffer.java",
     ],
     deps = [
+        "//src/main/java/com/google/devtools/build/lib/exec:spawn_log_context_utils",
+        "//src/main/java/com/google/devtools/build/lib/util/io:io-proto",
         "//src/main/java/com/google/devtools/common/options",
+        "//src/main/protobuf:spawn_java_proto",
+        "//third_party:guava",
     ]
 )

--- a/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/BUILD
+++ b/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/BUILD
@@ -55,5 +55,6 @@ java_library(
         "//src/main/java/com/google/devtools/common/options",
         "//src/main/protobuf:spawn_java_proto",
         "//third_party:guava",
+        "@maven//:com_google_code_gson_gson"
     ]
 )

--- a/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/BUILD
+++ b/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/BUILD
@@ -50,6 +50,7 @@ java_library(
         "ExecLogDiffer.java",
     ],
     deps = [
+        "//src/tools/execlog/src/main/java/com/google/devtools/build/execlog:parser",
         "//src/main/java/com/google/devtools/build/lib/exec:spawn_log_context_utils",
         "//src/main/java/com/google/devtools/build/lib/util/io:io-proto",
         "//src/main/java/com/google/devtools/common/options",

--- a/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/DifferOptions.java
+++ b/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/DifferOptions.java
@@ -1,0 +1,61 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.devtools.build.execlog;
+
+import com.google.devtools.common.options.Option;
+import com.google.devtools.common.options.OptionDocumentationCategory;
+import com.google.devtools.common.options.OptionEffectTag;
+import com.google.devtools.common.options.OptionsBase;
+import java.util.List;
+
+/** Options for execution log differ. */
+public class DifferOptions extends OptionsBase {
+  @Option(
+      name = "log_path",
+      defaultValue = "null", // Default value is null, allowing the check for size != 2
+      category = "logging",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      allowMultiple = true,
+      help =
+          "Exactly two log paths are required for comparison. The first log will be used as the"
+              + " 'golden' standard, and the actions in the second log will be reordered to match"
+              + " the first based on the first output's name. Actions unique to the second log"
+              + " will appear at the end.")
+  public List<String> logPath;
+
+  @Option(
+      name = "output_path",
+      defaultValue = "null", // Default value is null, allowing check for empty list
+      category = "logging",
+      documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+      effectTags = {OptionEffectTag.UNKNOWN},
+      // Note: ExecLogDiffer expects a single output path or null for stdout.
+      // allowMultiple = true as was in original file.
+      help =
+          "Location where to put the output of the comparison. If left empty, the output will be"
+              + " directed to stdout.")
+  public List<String> outputPath;
+
+  @Option(
+        name = "all_targets",
+        defaultValue = "false",
+        category = "logging",
+        documentationCategory = OptionDocumentationCategory.UNCATEGORIZED,
+        effectTags = {OptionEffectTag.UNKNOWN},
+        help = "If set, checks for non-determinism in all targets, including external dependencies ('@@' targets)."
+            + " If not set, only checks for non-determinism for targets inside the repository ('//' targets). "
+  )
+}

--- a/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/DifferOptions.java
+++ b/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/DifferOptions.java
@@ -47,7 +47,7 @@ public class DifferOptions extends OptionsBase {
       help =
           "Location where to put the output of the comparison. If left empty, the output will be"
               + " directed to stdout.")
-  public List<String> outputPath;
+  public String outputPath;
 
   @Option(
         name = "all_targets",
@@ -58,4 +58,5 @@ public class DifferOptions extends OptionsBase {
         help = "If set, checks for non-determinism in all targets, including external dependencies ('@@' targets)."
             + " If not set, only checks for non-determinism for targets inside the repository ('//' targets). "
   )
+  public boolean allTargets;
 }

--- a/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/ExecLogDiffer.java
+++ b/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/ExecLogDiffer.java
@@ -185,45 +185,49 @@ public final class ExecLogDiffer {
     // Computes diffs between the two SpawnExecDetails
     // This is only done for OUTPUT mismatches as they are easier to identify and fix
     private List<Diff> computeDiffs() {
-        List<Diff> diffs = new ArrayList<>();
-        if (mismatchType == MismatchType.OUTPUT && details != null && details2 != null) {
-            // Compare files in outputs
-            Set<String> outputPaths1 = new HashSet<>();
-            for (File file : details.outputs.files) {
-                outputPaths1.add(file.getPath());
-            }
-
-            Set<String> outputPaths2 = new HashSet<>();
-            for (File file : details2.outputs.files) {
-                outputPaths2.add(file.getPath());
-            }
-
-            // Find missing files in details
-            for (String path : outputPaths1) {
-                if (!outputPaths2.contains(path)) {
-                    diffs.add(new Diff(DiffType.MISSING_FILE, null, null, path));
-                }
-            }
-
-            // Find missing files in details2
-            for (String path : outputPaths2) {
-                if (!outputPaths1.contains(path)) {
-                    diffs.add(new Diff(DiffType.MISSING_FILE, null, null, path));
-                }
-            }
-
-            // Compare hashes for common files
-            for (File file1 : details.outputs.files) {
-                for (File file2 : details2.outputs.files) {
-                    if (file1.getPath().equals(file2.getPath())) {
-                        if (!file1.getDigest().getHash().equals(file2.getDigest().getHash())) {
-                            diffs.add(new Diff(DiffType.FILE_HASH, file1.getDigest().getHash(), file2.getDigest().getHash(), file1.getPath()));
-                        }
-                    }
-                }
-            }
+      List<Diff> diffs = new ArrayList<>();
+      if (mismatchType == MismatchType.OUTPUT && details != null && details2 != null) {
+        // Compare files in outputs
+        Set<String> outputPaths1 = new HashSet<>();
+        for (File file : details.outputs.files) {
+          outputPaths1.add(file.getPath());
         }
-        return diffs;
+
+        Set<String> outputPaths2 = new HashSet<>();
+        for (File file : details2.outputs.files) {
+          outputPaths2.add(file.getPath());
+        }
+
+        // Find missing files in details
+        for (String path : outputPaths1) {
+          if (!outputPaths2.contains(path)) {
+            diffs.add(new Diff(DiffType.MISSING_FILE, null, null, path));
+          }
+        }
+
+        // Find missing files in details2
+        for (String path : outputPaths2) {
+          if (!outputPaths1.contains(path)) {
+            diffs.add(new Diff(DiffType.MISSING_FILE, null, null, path));
+          }
+        }
+
+        // Compare hashes for common files
+        Map<String, String> fileHashes1 = new HashMap<>();
+        for (File file1 : details.outputs.files) {
+          fileHashes1.put(file1.getPath(), file1.getDigest().getHash());
+        }
+        
+        for (File file2 : details2.outputs.files) {
+          String hash1 = fileHashes1.get(file2.getPath());
+          if (hash1 != null) { // File exists in both outputs
+            if (!hash1.equals(file2.getDigest().getHash())) {
+              diffs.add(new Diff(DiffType.FILE_HASH, hash1, file2.getDigest().getHash(), file2.getPath()));
+            }
+          }
+        }
+      }
+      return diffs;
     }
   }
 

--- a/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/ExecLogDiffer.java
+++ b/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/ExecLogDiffer.java
@@ -1,0 +1,50 @@
+import com.google.common.annotations.VisibleForTesting;
+import com.google.devtools.build.lib.exec.Protos.SpawnExec;
+import com.google.devtools.build.lib.exec.SpawnLogReconstructor;
+import com.google.devtools.build.lib.util.io.MessageInputStream;
+import com.google.devtools.build.lib.util.io.MessageInputStreamWrapper.BinaryInputStreamWrapper;
+import com.google.devtools.build.lib.util.io.MessageInputStreamWrapper.JsonInputStreamWrapper;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.IOException;
+
+public final class ExecLogDiffer {
+  private ExecLogDiffer() {}
+
+  private static byte[] readFirstFourBytes(String path) throws IOException {
+    try (InputStream in = new FileInputStream(path)) {
+      return in.readNBytes(4);
+    }
+  }
+  @VisibleForTesting
+  static MessageInputStream<SpawnExec> getMessageInputStream(String path) throws IOException {
+    byte[] b = readFirstFourBytes(path);
+    if (b.length == 4
+        && b[0] == 0x28
+        && b[1] == (byte) 0xb5
+        && b[2] == 0x2f
+        && b[3] == (byte) 0xfd) {
+      // Looks like a compact file (zstd-compressed).
+      // This is definitely not a JSON file (the first byte is not '{') and definitely not a
+      // binary file (the first byte would indicate the size of the first message, and the
+      // second byte would indicate an invalid wire type).
+      return new SpawnLogReconstructor(new FileInputStream(path));
+    }
+    if (b.length >= 2 && b[0] == '{' && b[1] == '\n') {
+      // Looks like a JSON file.
+      // This is definitely not a compact file (the first byte is not 0x28) and definitely not a
+      // binary file (the first byte would indicate the size of the first message, and the
+      // second byte would indicate a field with number 1 and wire type I32, which doesn't match
+      // the proto definition).
+      return new JsonInputStreamWrapper<>(
+          new FileInputStream(path), SpawnExec.getDefaultInstance());
+    }
+    // Otherwise assume it's a binary file.
+    return new BinaryInputStreamWrapper<>(
+        new FileInputStream(path), SpawnExec.getDefaultInstance());
+  }
+
+  public static void main(String[] args) throws Exception {
+  
+  }
+}

--- a/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/ExecLogDiffer.java
+++ b/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/ExecLogDiffer.java
@@ -292,6 +292,11 @@ public final class ExecLogDiffer {
         int inputHash = details.inputHash;
         int outputHash = details.outputHash;
 
+        if (!allTargets && targetLabel.startsWith("@@")) {
+          // Skip external dependencies if allTargets is false
+          continue;
+        }
+
         // Add the action to the target actions map for that target label
         targetActionsMap
             .computeIfAbsent(targetLabel, k -> new HashMap<>())
@@ -307,6 +312,11 @@ public final class ExecLogDiffer {
         String targetLabel = details2.targetLabel;
         int inputHash2 = details2.inputHash;
         int outputHash2 = details2.outputHash;
+
+        if (!allTargets && targetLabel.startsWith("@@")) {
+          // Skip external dependencies if allTargets is false
+          continue;
+        }
   
         if (targetActionsMap.containsKey(targetLabel)) {
           // Check if the input hash from the second log matches any input hash in the first log for that target
@@ -335,6 +345,11 @@ public final class ExecLogDiffer {
         SpawnExecDetails details = new SpawnExecDetails(ex1);
         String targetLabel = details.targetLabel;
         int inputHash = details.inputHash;
+
+        if (!allTargets && targetLabel.startsWith("@@")) {
+          // Skip external dependencies if allTargets is false
+          continue;
+        }
     
         if (report.nonDeterministicTargets.containsKey(targetLabel)) {
           NonDeterministicTarget nonDetTarget = report.nonDeterministicTargets.get(targetLabel);

--- a/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/ExecLogDiffer.java
+++ b/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/ExecLogDiffer.java
@@ -183,6 +183,7 @@ public final class ExecLogDiffer {
     }
 
     // Computes diffs between the two SpawnExecDetails
+    // This is only done for OUTPUT mismatches as they are easier to identify and fix
     private List<Diff> computeDiffs() {
         List<Diff> diffs = new ArrayList<>();
         if (mismatchType == MismatchType.OUTPUT && details != null && details2 != null) {

--- a/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/ExecLogDiffer.java
+++ b/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/ExecLogDiffer.java
@@ -176,11 +176,13 @@ public final class ExecLogDiffer {
 
     static class Diff {
       String type; // e.g., "FILE_HASH", "FILE_PATH", "MISSING_FILE"
+      String path; // Path of the file if applicable
       String log1Value; // Value from the first log
       String log2Value; // Value from the second log
 
-      Diff(String type, String log1Value, String log2Value) {
+      Diff(String type, String log1Value, String log2Value, String path) {
         this.type = type;
+        this.path = path != null ? path : "";
         this.log1Value = log1Value;
         this.log2Value = log2Value;
       }
@@ -218,14 +220,14 @@ public final class ExecLogDiffer {
             // Find missing files in details
             for (String path : outputPaths1) {
                 if (!outputPaths2.contains(path)) {
-                    diffs.add(new Diff("MISSING_FILE", path, null));
+                    diffs.add(new Diff("MISSING_FILE", null, null, path));
                 }
             }
 
             // Find missing files in details2
             for (String path : outputPaths2) {
                 if (!outputPaths1.contains(path)) {
-                    diffs.add(new Diff("MISSING_FILE", null, path));
+                    diffs.add(new Diff("MISSING_FILE", null, null, path));
                 }
             }
 
@@ -234,7 +236,7 @@ public final class ExecLogDiffer {
                 for (File file2 : details2.outputs.files) {
                     if (file1.getPath().equals(file2.getPath())) {
                         if (!file1.getDigest().getHash().equals(file2.getDigest().getHash())) {
-                            diffs.add(new Diff("FILE_HASH", file1.getDigest().getHash(), file2.getDigest().getHash()));
+                            diffs.add(new Diff("FILE_HASH", file1.getDigest().getHash(), file2.getDigest().getHash(), file1.getPath()));
                         }
                     }
                 }

--- a/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/ExecLogDiffer.java
+++ b/src/tools/execlog/src/main/java/com/google/devtools/build/execlog/ExecLogDiffer.java
@@ -38,11 +38,11 @@ public final class ExecLogDiffer {
   // Assumes immutability: attributes are set once in the constructor and not modified later
   // Relies on precomputed hashes for comparisons
   static class SpawnExecDetails {
-    String targetLabel; // Label of the target for which this SpawnExec was created
-    Inputs inputs; // Inputs for the SpawnExec
-    Outputs outputs; // Outputs for the SpawnExec
-    int inputHash; // Hash of the inputs
-    int outputHash; // Hash of the outputs
+    final String targetLabel; // Label of the target for which this SpawnExec was created
+    final Inputs inputs; // Inputs for the SpawnExec
+    final Outputs outputs; // Outputs for the SpawnExec
+    final int inputHash; // Hash of the inputs
+    final int outputHash; // Hash of the outputs
 
     SpawnExecDetails(SpawnExec ex) {
       this.targetLabel = ex.getTargetLabel();
@@ -58,10 +58,10 @@ public final class ExecLogDiffer {
     }
 
     static class Inputs {
-      List<String> commandArgs; // List of command line arguments for action
-      List<EnvironmentVariable> environmentVariables; // List of input directory paths
-      Platform platform; // Platform information
-      List<File> files; // List of file details
+      final List<String> commandArgs; // List of command line arguments for action
+      final List<EnvironmentVariable> environmentVariables; // List of input directory paths
+      final Platform platform; // Platform information
+      final List<File> files; // List of file details
 
       Inputs(SpawnExec ex) {
         this.commandArgs = ex.getCommandArgsList();
@@ -77,7 +77,7 @@ public final class ExecLogDiffer {
     }
 
     static class Outputs {
-      List<File> files; // List of output file details
+      final List<File> files; // List of output file details
     
       Outputs(SpawnExec ex) {
         this.files = ex.getActualOutputsList();


### PR DESCRIPTION
This new tool helps you compare two large Bazel execution log files. Specifically, it identifies matching actions between the logs and then analyzes their inputs and outputs. It's built on top of the existing parser and converter tools, primarily using their ability to read proto log files.

### Basic Overview of Logic:
1) Processes each action from the first log and maps each input hash to its output hash. 
   - The input hash is computed based on the input files, environment variables, command arguments, and platform. 
   - The output hash is computed based on the output files.
   - The entire SpawnExec object containing the full details of the action is not stored because this is designed to work with very large execution logs.
2) Processes each action from the second log comparing input and output hashes to find mismatches (non-determinism).
   - The relevant details of the SpawnExec object whose action has a mismatch are saved along with information about what kind of mismatch.
3) Processes each action from the first log again saving details of only mismatched actions (found in the previous step) and computing easy to read diffs.
   - The diffs are computed because some of these objects have a ton of information. All the information is saved for further inspection, but only the most relevant differences are saved separately.
4) Saves the non-deterministic targets, with information about each mismatched action, in JSONL.

### Notes:
- I designed this tool to skip comparing actions with different inputs. Why? Because input mismatches (where an action's input in one log doesn't match the other) are typically much harder to resolve than output mismatches (where inputs match but outputs differ). Tackling input mismatches would demand complex logic and significant processing power. Plus, I believe most input discrepancies stem from upstream non-determinism (like an output mismatch in a dependency) rather than issues with Bazel rules themselves. Fixing those underlying output mismatches should, in theory, resolve most input mismatches. For these reasons, the effort to compare actions with different inputs just isn't worth the minimal benefit.
- For every non-deterministic Bazel target in our repo (`//` targets), there are hundreds of non-deterministic targets from external dependencies (`@@` targets). For that reason, unless you set the `--all_targets` flag, the tool will ignore external targets as it makes the output much bigger, and those are less important to us than our own targets. 

I'm pretty new to Bazel and determinism, so I'm open to different perspectives about all of this.

### Where This is Going:

This is designed to be used in a Jenkins job, periodically scanning for issues and providing actionable information to help resolve non-determinism in our codebase. The JSONL output can be parsed into a simple HTML webpage that can be an artifact of the Jenkins job. From this page, you can navigate the targets showing non-determinism in a file-explorer-like fashion. Here's what it looks like:

![image](https://github.com/user-attachments/assets/1fd779e4-567f-49ed-a859-f374174ded5f)
